### PR TITLE
WIP: Adding latest eventing and in-memory controller

### DIFF
--- a/knative-eventing/eventing.addon
+++ b/knative-eventing/eventing.addon
@@ -6,24 +6,24 @@
 
 ## temporary installing Strimzi
 oc apply -f https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.2/strimzi-cluster-operator-0.8.2.yaml
-oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.8.2/examples/kafka/kafka-persistent.yaml
+# Simple Cluster with one ZK and one Kafka node
+oc apply -f https://gist.githubusercontent.com/matzew/a57485deff91591a442dcf6c7ab16c87/raw/f908e91a66d6fc79a20c5988890d493b2bbf8eb0/strimzi.yaml
 
 ## ADM policies
 oc adm policy add-scc-to-user anyuid -z eventing-controller -n knative-eventing
-oc adm policy add-scc-to-user anyuid -z bus-operator -n knative-eventing
 oc adm policy add-cluster-role-to-user cluster-admin -z eventing-controller -n knative-eventing
-oc adm policy add-cluster-role-to-user cluster-admin -z bus-operator -n knative-eventing
+oc adm policy add-cluster-role-to-user cluster-admin -z default -n knative-sources
+oc adm policy add-scc-to-user anyuid -z in-memory-channel-dispatcher -n knative-eventing
+oc adm policy add-cluster-role-to-user cluster-admin -z in-memory-channel-dispatcher -n knative-eventing
+oc adm policy add-scc-to-user anyuid -z in-memory-channel-controller -n knative-eventing
+oc adm policy add-cluster-role-to-user cluster-admin -z in-memory-channel-controller -n knative-eventing
 
-oc apply -f https://raw.githubusercontent.com/openshift-cloud-functions/knative-operators/881d0b2e89eed0538126d5b11467296b07d1d91b/etc/upstream/knative-eventing-kafka-80860ba.yaml
+
+oc apply -f https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
+oc apply -f https://storage.googleapis.com/knative-releases/eventing-sources/latest/release.yaml
 
 # Wait up to 5 minutes for all pods to be ready
 token := oc sa get-token deployer -n knative-eventing
 ssh timeout 300 bash -c -- 'while curl -s -k -H "Authorization: Bearer #{token}" https://#{ip}:8443/api/v1/namespaces/knative-eventing/pods | grep phase | grep -v -E "(Running|Succeeded)"; do sleep 5; done'
 
-#Bridging to our Strimzi/Kafka install
-oc -n knative-eventing create configmap kafka-bus-config --from-literal=KAFKA_BOOTSTRAP_SERVERS=my-cluster-kafka-bootstrap.myproject.svc.cluster.local:9092
-
-#Bus and ClusterBus
-oc apply -f https://storage.googleapis.com/knative-releases/eventing/latest/release-bus-kafka.yaml
-oc apply -f https://storage.googleapis.com/knative-releases/eventing/latest/release-clusterbus-kafka.yaml
-
+## TODO: run Kafka Provisioner

--- a/knative-eventing/eventing.addon
+++ b/knative-eventing/eventing.addon
@@ -18,9 +18,9 @@ oc adm policy add-cluster-role-to-user cluster-admin -z in-memory-channel-dispat
 oc adm policy add-scc-to-user anyuid -z in-memory-channel-controller -n knative-eventing
 oc adm policy add-cluster-role-to-user cluster-admin -z in-memory-channel-controller -n knative-eventing
 
-
-oc apply -f https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
-oc apply -f https://storage.googleapis.com/knative-releases/eventing-sources/latest/release.yaml
+## Eventing and Eventing-Sources (pre) 0.2.0
+oc apply -f https://raw.githubusercontent.com/openshift-cloud-functions/knative-operators/d2bbb3553951590e7727f14ead229900429fd2b8/etc/upstream/knative-eventing-0.2.0.yaml
+oc apply -f https://raw.githubusercontent.com/openshift-cloud-functions/knative-operators/d2bbb3553951590e7727f14ead229900429fd2b8/etc/upstream/knative-eventing-sources-0.2.0.yaml
 
 # Wait up to 5 minutes for all pods to be ready
 token := oc sa get-token deployer -n knative-eventing

--- a/knative-eventing/eventing.addon.remove
+++ b/knative-eventing/eventing.addon.remove
@@ -8,6 +8,5 @@ oc adm policy remove-cluster-role-from-user cluster-admin -z eventing-controller
 oc adm policy remove-cluster-role-from-user cluster-admin -z bus-operator -n knative-eventing
 
 
-!oc delete -f https://raw.githubusercontent.com/openshift-cloud-functions/knative-operators/881d0b2e89eed0538126d5b11467296b07d1d91b/etc/upstream/knative-eventing-kafka-80860ba.yaml
-!oc delete -f https://storage.googleapis.com/knative-releases/eventing/latest/release-bus-kafka.yaml
-!oc delete -f https://storage.googleapis.com/knative-releases/eventing/latest/release-clusterbus-kafka.yaml
+!oc delete -f https://raw.githubusercontent.com/openshift-cloud-functions/knative-operators/d2bbb3553951590e7727f14ead229900429fd2b8/etc/upstream/knative-eventing-0.2.0.yaml
+!oc delete -f https://raw.githubusercontent.com/openshift-cloud-functions/knative-operators/d2bbb3553951590e7727f14ead229900429fd2b8/etc/upstream/knative-eventing-sources-0.2.0.yaml


### PR DESCRIPTION
After the installation of Knative-eventing, run the k8s/in-mem. demo

#### OC ADM fu

might be a bit too much...

```shell
oc adm policy add-scc-to-user anyuid -z default -n myproject
oc adm policy add-scc-to-user privileged -z default -n myproject
oc adm policy add-scc-to-user anyuid -z events-sa -n myproject
oc adm policy add-scc-to-user privileged -z events-sa -n myproject
oc adm policy add-scc-to-user anyuid -z default -n myproject
oc adm policy add-scc-to-user privileged -z default -n myproject
```

and deploy the sample (without `ko`):

```shell
oc apply -f https://gist.githubusercontent.com/matzew/8932b8dabfdbdff0ffc9012c24cac2c9/raw/cc6c25ab7b044d2214bfe8a238801afcd88faca0/k8s-sample.yaml
```