### PR TITLE
Add a new knative-build-pipeline addon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ After cloning this repo locally, install your desired addons:
 
     $ minishift addons install minishift-addons/knative-istio
     $ minishift addons install minishift-addons/knative-build
+    $ minishift addons install minishift-addons/knative-build-pipeline
     $ minishift addons install minishift-addons/knative-serving
     $ minishift addons install minishift-addons/knative-eventing
 
@@ -20,6 +21,7 @@ upstream knative-serving repo.
 Once that completes, install the knative resources you desire:
 
     $ minishift addons apply knative-build
+    $ minishift addons apply knative-build-pipeline
     $ minishift addons apply knative-serving
     $ minishift addons apply knative-eventing
 
@@ -35,6 +37,7 @@ example:
 You can remove the resources created by each addon like so:
 
     $ minishift addons remove knative-build
+    $ minishift addons remove knative-build-pipeline
     $ minishift addons remove knative-serving
     $ minishift addons remove knative-eventing
     $ minishift addons remove knative-istio
@@ -44,6 +47,7 @@ You can remove the resources created by each addon like so:
 And you can uninstall the addons thusly:
 
     $ minishift addons uninstall knative-build
+    $ minishift addons uninstall knative-build-pipeline
     $ minishift addons uninstall knative-serving
     $ minishift addons uninstall knative-eventing
     $ minishift addons uninstall knative-istio
@@ -58,6 +62,7 @@ each addon may be optionally configured with any older version you
 wish to install by setting an addon environment variable. For example,
 
     $ minishift addons apply --addon-env KNATIVE_BUILD_VERSION=v0.2.0 knative-build
+    $ minishift addons apply --addon-env KNATIVE_BUILD_PIPELINE_VERSION=previous/v20181204-559397d7-dirty knative-build-pipeline
     $ minishift addons apply --addon-env KNATIVE_SERVING_VERSION=v0.2.2 knative-serving
     $ minishift addons apply --addon-env KNATIVE_EVENTING_VERSION=v0.2.0 knative-eventing
 

--- a/knative-build-pipeline/build.addon
+++ b/knative-build-pipeline/build.addon
@@ -1,0 +1,24 @@
+# Name: knative-build-pipeline
+# Description: Install knative build-pipeline resources
+# OpenShift-Version: >=3.11.0
+# Minishift-Version: >=1.25.0
+# Depends-On: anyuid
+# Required-Vars: KNATIVE_BUILD_PIPELINE_VERSION
+# Var-Defaults: KNATIVE_BUILD_PIPELINE_VERSION=latest
+
+# To avoid an error when removing
+oc annotate clusterrolebinding.rbac cluster-admin 'rbac.authorization.kubernetes.io/autoupdate=false' --overwrite
+oc annotate clusterrolebinding.rbac cluster-admins 'rbac.authorization.kubernetes.io/autoupdate=false' --overwrite
+
+oc adm policy add-scc-to-user anyuid -z build-pipeline-controller -n knative-build-pipeline
+
+# Image CRD's may be referenced before they're applied so we ignore the return code
+# once we have actual releases
+# !oc apply -f https://github.com/knative/build-pipeline/releases/download/#{KNATIVE_BUILD_PIPELINE_VERSION}/release.yaml
+!oc apply -f https://storage.googleapis.com/knative-nightly/build-pipeline/#{KNATIVE_BUILD_PIPELINE_VERSION}/release.yaml
+
+oc adm policy add-cluster-role-to-user cluster-admin -z build-pipeline-controller -n knative-build-pipeline
+
+# Wait up to 5 minutes for all pods to be ready
+token := oc sa get-token deployer -n knative-build-pipeline
+ssh timeout 300 bash -c -- 'while curl -s -k -H "Authorization: Bearer #{token}" https://#{ip}:8443/api/v1/namespaces/knative-build-pipeline/pods | grep phase | grep -v -E "(Running|Succeeded)"; do sleep 5; done'

--- a/knative-build-pipeline/build.addon.remove
+++ b/knative-build-pipeline/build.addon.remove
@@ -1,0 +1,11 @@
+# Name: knative-build-pipeline
+# Description: Revert knative build-pipeline install
+# Required-Vars: KNATIVE_BUILD_PIPELINE_VERSION
+# Var-Defaults: KNATIVE_BUILD_PIPELINE_VERSION=latest
+
+oc adm policy remove-scc-from-user anyuid -z build-controller-pipeline -n knative-build-pipeline
+!oc adm policy remove-cluster-role-from-user cluster-admin -z build-controller-pipeline -n knative-build-pipeline
+
+# Once we have actual releases
+# !oc delete -f https://github.com/knative/build-pipeline/releases/download/#{KNATIVE_BUILD_PIPELINE_VERSION}/release.yaml
+!oc delete -f https://storage.googleapis.com/knative-nightly/build-pipeline/#{KNATIVE_BUILD_PIPELINE_VERSION}/release.yaml


### PR DESCRIPTION
It installs knative/build-pipeline from the nightly release for now as
there is no actual releases.

This is mainly to be able to try it without having to get the sources & co :angel: 

/cc @jcrossley3 @matzew @arilivigni 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>